### PR TITLE
Fiber scheduler address resolve - refactor

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -284,95 +284,6 @@ numeric_getaddrinfo(const char *node, const char *service,
     return EAI_FAIL;
 }
 
-static char* host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr);
-
-int
-rb_schedule_getaddrinfo(VALUE scheduler, VALUE host, const char *service,
-               const struct addrinfo *hints, struct rb_addrinfo **res)
-{
-    int ret, res_allocated = 0, _additional_flags = 0;
-    long i, len;
-    struct addrinfo *ai, *ai_tail = NULL;
-    char *hostp;
-    char _hbuf[NI_MAXHOST];
-    VALUE ip_addresses_array, ip_address;
-
-    ip_addresses_array = rb_fiber_scheduler_address_resolve(scheduler, host);
-    if (NIL_P(ip_addresses_array)) {
-        len = 0;
-    } else {
-        len = RARRAY_LEN(ip_addresses_array);
-    }
-
-    for(i=0; i<len; i++) {
-        ip_address = rb_ary_entry(ip_addresses_array, i);
-        hostp = host_str(ip_address, _hbuf, sizeof(_hbuf), &_additional_flags);
-        ret = numeric_getaddrinfo(hostp, service, hints, &ai);
-        if (ret == 0) {
-            if (!res_allocated) {
-                res_allocated = 1;
-                *res = (struct rb_addrinfo *)xmalloc(sizeof(struct rb_addrinfo));
-                (*res)->allocated_by_malloc = 1;
-                (*res)->ai = ai;
-                ai_tail = ai;
-            } else {
-                while (ai_tail->ai_next) {
-                    ai_tail = ai_tail->ai_next;
-                }
-                ai_tail->ai_next = ai;
-                ai_tail = ai;
-            }
-        }
-    }
-
-    if (res_allocated) { // At least one valid result.
-        return 0;
-    } else {
-        rsock_raise_socket_error("getaddrinfo", EAI_NONAME);
-    }
-}
-
-static int
-rb_getaddrinfo(const char *node, const char *service,
-               const struct addrinfo *hints,
-               struct rb_addrinfo **res)
-{
-    struct addrinfo *ai;
-    int ret;
-    int allocated_by_malloc = 0;
-
-    ret = numeric_getaddrinfo(node, service, hints, &ai);
-    if (ret == 0)
-        allocated_by_malloc = 1;
-    else {
-        VALUE scheduler = rb_fiber_scheduler_current();
-
-        if (scheduler != Qnil && node && !(hints->ai_flags & AI_NUMERICHOST) &&
-            strncmp(node, "localhost", strlen(node))) {
-            return rb_schedule_getaddrinfo(scheduler, host, service, hints, res);
-        } else {
-#ifdef GETADDRINFO_EMU
-            ret = getaddrinfo(node, service, hints, &ai);
-#else
-            struct getaddrinfo_arg arg;
-            MEMZERO(&arg, struct getaddrinfo_arg, 1);
-            arg.node = node;
-            arg.service = service;
-            arg.hints = hints;
-            arg.res = &ai;
-            ret = (int)(VALUE)rb_thread_call_without_gvl(nogvl_getaddrinfo, &arg, RUBY_UBF_IO, 0);
-#endif
-        }
-    }
-
-    if (ret == 0) {
-        *res = (struct rb_addrinfo *)xmalloc(sizeof(struct rb_addrinfo));
-        (*res)->allocated_by_malloc = allocated_by_malloc;
-        (*res)->ai = ai;
-    }
-    return ret;
-}
-
 void
 rb_freeaddrinfo(struct rb_addrinfo *ai)
 {
@@ -553,10 +464,57 @@ port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr)
     }
 }
 
+static int
+rb_schedule_getaddrinfo(VALUE scheduler, VALUE host, const char *service,
+               const struct addrinfo *hints, struct rb_addrinfo **res)
+{
+    int error, res_allocated = 0, _additional_flags = 0;
+    long i, len;
+    struct addrinfo *ai, *ai_tail = NULL;
+    char *hostp;
+    char _hbuf[NI_MAXHOST];
+    VALUE ip_addresses_array, ip_address;
+
+    ip_addresses_array = rb_fiber_scheduler_address_resolve(scheduler, host);
+    if (NIL_P(ip_addresses_array)) {
+        len = 0;
+    } else {
+        len = RARRAY_LEN(ip_addresses_array);
+    }
+
+    for(i=0; i<len; i++) {
+        ip_address = rb_ary_entry(ip_addresses_array, i);
+        hostp = host_str(ip_address, _hbuf, sizeof(_hbuf), &_additional_flags);
+        error = numeric_getaddrinfo(hostp, service, hints, &ai);
+        if (error == 0) {
+            if (!res_allocated) {
+                res_allocated = 1;
+                *res = (struct rb_addrinfo *)xmalloc(sizeof(struct rb_addrinfo));
+                (*res)->allocated_by_malloc = 1;
+                (*res)->ai = ai;
+                ai_tail = ai;
+            } else {
+                while (ai_tail->ai_next) {
+                    ai_tail = ai_tail->ai_next;
+                }
+                ai_tail->ai_next = ai;
+                ai_tail = ai;
+            }
+        }
+    }
+
+    if (res_allocated) { // At least one valid result.
+        return 0;
+    } else {
+        return EAI_NONAME;
+    }
+}
+
 struct rb_addrinfo*
 rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_hack)
 {
     struct rb_addrinfo* res = NULL;
+    struct addrinfo *ai;
     char *hostp, *portp;
     int error;
     char hbuf[NI_MAXHOST], pbuf[NI_MAXSERV];
@@ -570,7 +528,37 @@ rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_h
     }
     hints->ai_flags |= additional_flags;
 
-    error = rb_getaddrinfo(host, hostp, portp, hints, &res);
+    error = numeric_getaddrinfo(hostp, portp, hints, &ai);
+    if (error == 0) {
+        res = (struct rb_addrinfo *)xmalloc(sizeof(struct rb_addrinfo));
+        res->allocated_by_malloc = 1;
+        res->ai = ai;
+    } else {
+        VALUE scheduler = rb_fiber_scheduler_current();
+
+        if (scheduler != Qnil && hostp && !(hints->ai_flags & AI_NUMERICHOST) &&
+            strncmp(hostp, "localhost", strlen(hostp))) {
+            error = rb_schedule_getaddrinfo(scheduler, host, portp, hints, &res);
+        } else {
+#ifdef GETADDRINFO_EMU
+            error = getaddrinfo(hostp, portp, hints, &ai);
+#else
+            struct getaddrinfo_arg arg;
+            MEMZERO(&arg, struct getaddrinfo_arg, 1);
+            arg.node = hostp;
+            arg.service = portp;
+            arg.hints = hints;
+            arg.res = &ai;
+            error = (int)(VALUE)rb_thread_call_without_gvl(nogvl_getaddrinfo, &arg, RUBY_UBF_IO, 0);
+#endif
+            if (error == 0) {
+                res = (struct rb_addrinfo *)xmalloc(sizeof(struct rb_addrinfo));
+                res->allocated_by_malloc = 0;
+                res->ai = ai;
+            }
+        }
+    }
+
     if (error) {
         if (hostp && hostp[strlen(hostp)-1] == '\n') {
             rb_raise(rb_eSocket, "newline at the end of hostname");

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -332,8 +332,8 @@ rb_schedule_getaddrinfo(VALUE scheduler, VALUE host, const char *service,
     }
 }
 
-int
-rb_getaddrinfo(VALUE host, const char *node, const char *service,
+static int
+rb_getaddrinfo(const char *node, const char *service,
                const struct addrinfo *hints,
                struct rb_addrinfo **res)
 {

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -314,7 +314,6 @@ struct rb_addrinfo {
   struct addrinfo *ai;
   int allocated_by_malloc;
 };
-int rb_getaddrinfo(VALUE host, const char *node, const char *service, const struct addrinfo *hints, struct rb_addrinfo **res);
 void rb_freeaddrinfo(struct rb_addrinfo *ai);
 VALUE rsock_freeaddrinfo(VALUE arg);
 int rb_getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, size_t hostlen, char *serv, size_t servlen, int flags);

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1279,34 +1279,10 @@ sock_s_getnameinfo(int argc, VALUE *argv, VALUE _)
 	    rb_raise(rb_eArgError, "array size should be 3 or 4, %ld given",
 		     RARRAY_LEN(sa));
 	}
-	/* host */
-	if (NIL_P(host)) {
-	    hptr = NULL;
-	}
-	else {
-	    strncpy(hbuf, StringValueCStr(host), sizeof(hbuf));
-	    hbuf[sizeof(hbuf) - 1] = '\0';
-	    hptr = hbuf;
-	}
-	/* port */
-	if (NIL_P(port)) {
-	    strcpy(pbuf, "0");
-	    pptr = NULL;
-	}
-	else if (FIXNUM_P(port)) {
-	    snprintf(pbuf, sizeof(pbuf), "%ld", NUM2LONG(port));
-	    pptr = pbuf;
-	}
-	else {
-	    strncpy(pbuf, StringValueCStr(port), sizeof(pbuf));
-	    pbuf[sizeof(pbuf) - 1] = '\0';
-	    pptr = pbuf;
-	}
 	hints.ai_socktype = (fl & NI_DGRAM) ? SOCK_DGRAM : SOCK_STREAM;
 	/* af */
         hints.ai_family = NIL_P(af) ? PF_UNSPEC : rsock_family_arg(af);
-	error = rb_getaddrinfo(host, hptr, pptr, &hints, &res);
-	if (error) goto error_exit_addr;
+	res = rsock_getaddrinfo(host, port, &hints, 0);
 	sap = res->ai->ai_addr;
         salen = res->ai->ai_addrlen;
     }
@@ -1335,12 +1311,6 @@ sock_s_getnameinfo(int argc, VALUE *argv, VALUE _)
 	rb_freeaddrinfo(res);
     }
     return rb_assoc_new(rb_str_new2(hbuf), rb_str_new2(pbuf));
-
-  error_exit_addr:
-    saved_errno = errno;
-    if (res) rb_freeaddrinfo(res);
-    errno = saved_errno;
-    rsock_raise_socket_error("getaddrinfo", error);
 
   error_exit_name:
     saved_errno = errno;


### PR DESCRIPTION
Hi,

this PR contains a refactor of "fiber scheduler address resolve" based on your slack comment: https://socketry.slack.com/archives/CUK8PBRPG/p1619220128109600

Work done here is:

1. Refactor `sock_s_getnameinfo` to call `rsock_getaddrinfo` instead of `rb_getaddrinfo`
2. Merge `rb_getaddrinfo` into `rsock_getaddrinfo`
3. Delete `rb_getaddrinfo`

The PR contains a lot of diff, but the actual changes are not that big.
This is a pure refactor, the behavior is the same.